### PR TITLE
Minor fix in example "ex-async.R": "summarize_each()" is deprecated

### DIFF
--- a/example/ex-async.R
+++ b/example/ex-async.R
@@ -11,6 +11,6 @@ cat("unless directed to a file", file = "out.Rout")
 df %>% 
   mutate(group = cut(rating, nGroups, ordered = T)) %>% 
   group_by(group) %>% 
-  summarize_each(funs_(fxn)) %>%
+  summarize_all(funs_(fxn)) %>%
   select(group, rating, advance) %>%
   mutate(group = as.character(group))


### PR DESCRIPTION
`summarize_each()` is deprecated in the current version of dplyr (0.7.4).
This causes the current version of the example to fail with an exception.
Replaced it with `summarize_all()`