### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ cat("unless directed to a file", file = "out.Rout")
 df %>% 
   mutate(group = cut(rating, nGroups, ordered = T)) %>% 
   group_by(group) %>% 
-  summarize_each(funs_(fxn)) %>%
+  summarize_all(funs_(fxn)) %>%
   select(group, rating, advance) %>%
   mutate(group = as.character(group))
 ```


### PR DESCRIPTION
summarize_each() is deprecated in the current version of dplyr (0.7.4)