### PR TITLE
fix: wrap success return into try catch to avoid server side fatal error

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,11 @@ R.prototype.call = function(_opts, _callback) {
      body += d;
   });
   child.on("close", function(code) {
-    callback(null, JSON.parse(body));
+      try {
+        callback(null, JSON.parse(body));
+      } catch(err) {
+        callback(err, null);
+      }
   });
 };
 


### PR DESCRIPTION
When we are running the script and the R code throw an error the close callback is called with non parsable body and crash the node js application. 

To "gracefully" handle the error the proposition is to wrap the code into a try/catch and return the error instead of the body ;